### PR TITLE
Use text presentation selector on chun character

### DIFF
--- a/src/components/grid/Cell.tsx
+++ b/src/components/grid/Cell.tsx
@@ -1,4 +1,5 @@
 import { CharStatus } from '../../lib/statuses'
+import { normalize } from '../../lib/normalize'
 import classnames from 'classnames'
 
 type Props = {
@@ -22,5 +23,5 @@ export const Cell = ({ value, status }: Props) => {
     }
   )
 
-  return <div className={classes}>{value}</div>
+  return <div className={classes}>{normalize(value)}</div>
 }

--- a/src/components/keyboard/Key.tsx
+++ b/src/components/keyboard/Key.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 import classnames from 'classnames'
 import { KeyValue } from '../../lib/keyboard'
 import { CharStatus } from '../../lib/statuses'
+import { normalize } from '../../lib/normalize'
 
 type Props = {
   children?: ReactNode
@@ -42,7 +43,7 @@ export const Key = ({
       className={classes}
       onClick={handleClick}
     >
-      {children || value}
+      {children || normalize(value)}
     </button>
   )
 }

--- a/src/lib/normalize.ts
+++ b/src/lib/normalize.ts
@@ -1,0 +1,4 @@
+import { KeyValue } from './keyboard'
+
+export const normalize = (value: KeyValue | string | undefined) =>
+  value === '🀄' ? `${value}\uFE0E` : value


### PR DESCRIPTION
Uses the [Text Presentation Selector](http://www.unicode.org/reports/tr51/#def_text_presentation_selector) to render the Chun character as text instead of an emoji for a consistent look.
![Screenshot from 2022-02-08 02-00-57](https://user-images.githubusercontent.com/2748721/152927874-1f69f0af-79f3-4d54-b244-156fe89d85db.png)
Note that some browsers ignore the standard and render it as an emoji anyways.