### PR TITLE
added MH link to share text

### DIFF
--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -1,4 +1,5 @@
 export const GAME_TITLE = 'Mahjong Handle'
+export const GAME_URL = 'https://mahjong-handle.update.sh/'
 
 export const WIN_MESSAGES = ['Great Job!', 'Awesome', 'Well done!']
 export const GAME_COPIED_MESSAGE = 'Game copied to clipboard'

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -2,6 +2,7 @@ import GraphemeSplitter from 'grapheme-splitter'
 import { getGuessStatuses } from './statuses'
 import { solutionIndex } from './words'
 import { GAME_TITLE } from '../constants/strings'
+import { GAME_URL } from '../constants/strings'
 import { GUESS_MAX } from '../constants/settings'
 
 const graphemeSplitter = new GraphemeSplitter()
@@ -10,7 +11,7 @@ export const shareStatus = (guesses: string[], lost: boolean) => {
   navigator.clipboard.writeText(
     `${GAME_TITLE} ${solutionIndex} ${
       lost ? 'X' : guesses.length
-    }/${GUESS_MAX}\n\n` + generateEmojiGrid(guesses)
+    }/${GUESS_MAX}\n${GAME_URL}\n\n` + generateEmojiGrid(guesses)
   )
 }
 


### PR DESCRIPTION
Every time I share my results on Twitter ([@KnomoSeikei](https://twitter.com/KnomoSeikei)) I add manually some info. 
The link (https://mahjong-handle.update.sh/) is one of the most generic information needed, as the intention is to share the site/game.
You can check this [example](https://twitter.com/KnomoSeikei/status/1511793660328923136) with some other hashtags I like to include.